### PR TITLE
Hinzufügen von "requestedStartTime" zu AutomaticPreconditioning

### DIFF
--- a/v1.1/BootNotificationRequest.json
+++ b/v1.1/BootNotificationRequest.json
@@ -1,0 +1,27 @@
+{
+   "$schema": "http://json-schema.org/draft-04/schema#",
+   "$id": "urn:VDV463:1:0:0:BootNotificationRequest",
+   "comment": "VDV463 1.0.0 FINAL",
+   "title": "BootNotificationRequest",
+   "description": "This type represents the data sent by the presystem to the load management system as a result associated with a successful boot of the presystem.",
+   "additionalProperties": false,
+   "type": "object",
+   "properties": {
+      "presystem": {
+         "$ref": "#/definitions/PresystemEnumType"
+      }
+   },
+   "required": [
+      "presystem"
+   ],
+   "definitions": {
+      "PresystemEnumType": {
+         "additionalProperties": false,
+         "type": "string",
+         "enum": [
+            "BMS",
+            "ITCS"
+         ]
+      }
+   }
+}

--- a/v1.1/BootNotificationResponse.json
+++ b/v1.1/BootNotificationResponse.json
@@ -1,0 +1,27 @@
+{
+   "$schema": "http://json-schema.org/draft-04/schema#",
+   "$id": "urn:VDV463:1:0:0:BootNotificationResponse",
+   "comment": "VDV463 1.0.0 FINAL",
+   "title": "BootNotificationResponse",
+   "description": "This type represents the response data sent by the load management system to the presystem as a result associated with the boot notification previously sent by the presystem.",
+   "type": "object",
+   "additionalProperties": false,
+   "properties": {
+      "status": {
+         "$ref": "#/definitions/BootNotificationStatusEnumType"
+      }
+   },
+   "required": [
+      "status"
+   ],
+   "definitions": {
+      "BootNotificationStatusEnumType": {
+         "type": "string",
+         "additionalProperties": false,
+         "enum": [
+            "Accepted",
+            "Rejected"
+         ]
+      }
+   }
+}

--- a/v1.1/MessageStructure.json
+++ b/v1.1/MessageStructure.json
@@ -1,0 +1,60 @@
+{
+   "$schema": "http://json-schema.org/draft-04/schema#",
+   "$id": "urn:VDV463:1:0:0:MessageStructure",
+   "comment": "VDV463 1.0.0 FINAL",
+   "title": "MessageStructure",
+   "type": "array",
+   "additionalProperties": false,
+   "description": "This type represents a generic message structure associated with the VDV463.",
+   "items": [
+      {
+         "type": "integer",
+         "additionalProperties": false,
+         "description": "This type represents the message type.",
+         "enum": [
+            1,
+            2,
+            3
+         ]
+      },
+      {
+         "type": "string",
+         "additionalProperties": false,
+         "description": "This type represents the source of the data of the message."
+      },
+      {
+         "description": "This type represents an unique identifier for the presystemId according to RFC3986.",
+         "type": "string",
+         "additionalProperties": false,
+         "format": "uri"
+      },
+      {
+         "type": "string",
+         "additionalProperties": false,
+         "description": "This type represents the current timestamp of the message.",
+         "format": "date-time"
+      },
+      {
+         "type": "string",
+         "additionalProperties": false,
+         "description": "This type represents the unique identifier of the message.",
+         "format": "uuid"
+      },
+      {
+         "type": "string",
+         "additionalProperties": false,
+         "description": "This type represents the action of the message.",
+         "enum": [
+            "BootNotification",
+            "ProvideChargingRequests",
+            "ProvideChargingInformation"
+         ]
+      },
+      {
+         "type": "object",
+         "description": "This type represents the payload of the message which is specified in separate JSON schemas."
+      }
+   ],
+   "minItems": 7,
+   "maxItems": 7
+}

--- a/v1.1/ProvideChargingInformationRequest.json
+++ b/v1.1/ProvideChargingInformationRequest.json
@@ -1,0 +1,550 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$id": "urn:VDV463:1:0:0:ProvideChargingInformationRequest",
+	"comment": "VDV463 1.0.0 FINAL",
+	"title": "ProvideChargingInformationRequest",
+	"description": "This type represents charging information sent by a load management system to a presystem.",
+	"type": "object",
+	"properties": {
+		"depotInfoList": {
+			"type": "array",
+			"minItems": 1,
+			"items": {
+				"$ref": "#/definitions/DepotInfo"
+			},
+			"additionalProperties": false
+		}
+	},
+	"required": [
+		"depotInfoList"
+	],
+	"additionalProperties": false,
+	"definitions": {
+		"VehicleIdentifier": {
+			"description": "This type represents an unique vehicle identifier associated with VDV261.",
+			"type": "string",
+			"additionalProperties": false
+		},
+		"UniqueIdentifier": {
+			"description": "This type represents an unique identifier according to RFC3986.",
+			"type": "string",
+			"format": "uri",
+			"additionalProperties": false
+		},
+		"ChargingStationFaultInfo": {
+			"description": "This type represents error information regarding charging stations.",
+			"type": "object",
+			"properties": {
+				"chargingStationFaultCode": {
+					"$ref": "#/definitions/ChargingStationFaultCode"
+				},
+				"faultText": {
+					"type": "string",
+					"additionalProperties": false
+				},
+				"faultTimeStamp": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"chargingStationFaultCode",
+				"faultTimeStamp"
+			],
+			"additionalProperties": false
+		},
+		"ChargingStationFaultCode": {
+			"description": "This type represents error codes regarding faults at the charging station.",
+			"type": "string",
+			"additionalProperties": false,
+			"enum": [
+				"NoFaultKnown",
+				"UsageFailure",
+				"CommunicationFailure",
+				"ElectricalOperationFailure",
+				"ConfigurationFailure",
+				"OtherChargingStationFailure"
+			]
+		},
+		"ChargingPointStatus": {
+			"type": "string",
+			"additionalProperties": false,
+			"enum": [
+				"Available",
+				"Occupied",
+				"Reserved",
+				"Unavailable",
+				"Faulted"
+			]
+		},
+		"ChargingStationStatus": {
+			"type": "string",
+			"additionalProperties": false,
+			"enum": [
+				"Available",
+				"Unavailable",
+				"Faulted"
+			]
+		},
+		"ChargingPointFaultInfo": {
+			"description": "This type represents information regarding a fault at the charging point.",
+			"type": "object",
+			"properties": {
+				"chargingPointFaultCode": {
+					"$ref": "#/definitions/ChargingPointFaultCode"
+				},
+				"faultText": {
+					"type": "string",
+					"additionalProperties": false
+				},
+				"faultTimeStamp": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"chargingPointFaultCode",
+				"faultTimeStamp"
+			],
+			"additionalProperties": false
+		},
+		"ChargingPointFaultCode": {
+			"description": "This type represents error codes regarding faults at the charging point.",
+			"type": "string",
+			"additionalProperties": false,
+			"enum": [
+				"NoFaultKnown",
+				"UsageFailure",
+				"CommunicationFailure",
+				"OtherChargingPointFailure"
+			]
+		},
+		"ProcessStatus": {
+			"type": "string",
+			"additionalProperties": false,
+			"enum": [
+				"Preparing",
+				"Charging",
+				"SuspendedEVSE",
+				"SuspendedEV",
+				"Finishing",
+				"Queued",
+				"ChargingRejectedTechnically"
+			]
+		},
+		"TractionBatteryInfo": {
+			"description": "This type represents information regarding a traction battery.",
+			"type": "object",
+			"properties": {
+				"stateOfHealth": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"stateOfCharge": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"temperature": {
+					"type": "integer",
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"VehicleStatusInfo": {
+			"description": "This type represents status information regarding a vehicle.",
+			"type": "object",
+			"properties": {
+				"conservationChargingActive": {
+					"type": "boolean",
+					"additionalProperties": false
+				},
+				"systemPreconditioningActive": {
+					"type": "boolean",
+					"additionalProperties": false
+				},
+				"hvacPreconditioningActive": {
+					"type": "boolean",
+					"additionalProperties": false
+				},
+				"balancingActive": {
+					"type": "boolean",
+					"additionalProperties": false
+				},
+				"fossilFlameControlActive": {
+					"type": "boolean",
+					"additionalProperties": false
+				},
+				"batteryChargingVoltage": {
+					"type": "number",
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"VehicleChargingStatus": {
+			"type": "string",
+			"additionalProperties": false,
+			"enum": [
+				"ReadyToCharge",
+				"Charging",
+				"ChargingImpossible",
+				"Unknown"
+			]
+		},
+		"VehicleFaultInfo": {
+			"description": "This type represents error information regarding vehicles.",
+			"type": "object",
+			"properties": {
+				"vehicleFaultCode": {
+					"$ref": "#/definitions/VehicleFaultCode"
+				},
+				"faultText": {
+					"type": "string",
+					"additionalProperties": false
+				},
+				"faultTimeStamp": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"vehicleFaultCode",
+				"faultTimeStamp"
+			],
+			"additionalProperties": false
+		},
+		"VehicleFaultCode": {
+			"description": "This type represents error codes regarding faults at vehicles.",
+			"type": "string",
+			"additionalProperties": false
+		},
+		"PreconditioningInfo": {
+			"description": "This type represents information regarding preconditioning according to VDV261.",
+			"type": "object",
+			"properties": {
+				"hvBatteryPreconditioningTime": {
+					"type": "integer",
+					"additionalProperties": false
+				},
+				"hvBatteryChargingEnergy": {
+					"type": "integer",
+					"additionalProperties": false
+				},
+				"vehiclePreconditioningTime": {
+					"type": "integer",
+					"additionalProperties": false
+				},
+				"vehiclePreconditioningEnergy": {
+					"type": "integer",
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"VehicleInfo": {
+			"description": "This type represents information regarding a vehicle.",
+			"type": "object",
+			"properties": {
+				"vehicleId": {
+					"$ref": "#/definitions/VehicleIdentifier"
+				},
+				"mileage": {
+					"type": "integer",
+					"additionalProperties": false
+				},
+				"tractionBatteryInfo": {
+					"$ref": "#/definitions/TractionBatteryInfo"
+				},
+				"vehicleStatusInfo": {
+					"$ref": "#/definitions/VehicleStatusInfo"
+				},
+				"vehicleChargingStatus": {
+					"$ref": "#/definitions/VehicleChargingStatus"
+				},
+				"vehicleFaultInfo": {
+					"$ref": "#/definitions/VehicleFaultInfo"
+				},
+				"preconditioningInfo": {
+					"$ref": "#/definitions/PreconditioningInfo"
+				}
+			},
+			"required": [
+				"vehicleId",
+				"vehicleStatusInfo",
+				"vehicleChargingStatus",
+				"preconditioningInfo"
+			],
+			"additionalProperties": false
+		},
+		"ElectricData": {
+			"description": "This type represents electrical values for the current charging process.",
+			"type": "object",
+			"properties": {
+				"chargingCurrent": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"chargingVoltage": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"chargingPower": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"reactivePower": {
+					"type": "number",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"chargingPower"
+			],
+			"additionalProperties": false
+		},
+		"ChargingProcessInfo": {
+			"description": "This type represents information regarding a charging process.",
+			"type": "object",
+			"properties": {
+				"presystemId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"chargingRequestId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"chargingProcessId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"processStatus": {
+					"$ref": "#/definitions/ProcessStatus"
+				},
+				"startTime": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				},
+				"chargingPredictionData": {
+					"$ref": "#/definitions/ChargingPredictionData"
+				},
+				"electricData": {
+					"$ref": "#/definitions/ElectricData"
+				},
+				"deliveredEnergy": {
+					"type": "number",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"chargingProcessId",
+				"processStatus",
+				"startTime",
+				"chargingPredictionData",
+				"electricData"
+			],
+			"additionalProperties": false
+		},
+		"ChargingPredictionData": {
+			"description": "This type represents information regarding a charging process forecast.",
+			"type": "object",
+			"properties": {
+				"chargingPredictionDataMinSoc": {
+					"$ref": "#/definitions/ChargingPredictionDataMinSoc"
+				},
+				"chargingPredictionDataFinalSoc": {
+					"$ref": "#/definitions/ChargingPredictionDataFinalSoc"
+				}
+			},
+			"required": [
+				"chargingPredictionDataMinSoc"
+			],
+			"additionalProperties": false
+		},
+		"ChargingPredictionDataMinSoc": {
+			"description": "This type represents information regarding a charging process forecast.",
+			"type": "object",
+			"properties": {
+				"requestedMinSoc": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"predictedTime": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"requestedMinSoc",
+				"predictedTime"
+			],
+			"additionalProperties": false
+		},
+		"ChargingPredictionDataFinalSoc": {
+			"description": "This type represents information regarding a charging process forecast.",
+			"type": "object",
+			"properties": {
+				"predictedFinalSoc": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"predictedTime": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"predictedFinalSoc",
+				"predictedTime"
+			],
+			"additionalProperties": false
+		},
+		"ChargingPointInfo": {
+			"type": "object",
+			"properties": {
+				"chargingPointId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"chargingPointStatus": {
+					"$ref": "#/definitions/ChargingPointStatus"
+				},
+				"insideTemperature": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"outsideTemperature": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"connectorTemperature": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"presentPower": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"energyMeterReading": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"chargingPointFaultInfo": {
+					"$ref": "#/definitions/ChargingPointFaultInfo"
+				},
+				"vehicleInfo": {
+					"$ref": "#/definitions/VehicleInfo"
+				},
+				"chargingProcessInfo": {
+					"$ref": "#/definitions/ChargingProcessInfo"
+				},
+				"scheduledChargingProcessList": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/ScheduledChargingProcess"
+					},
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"chargingPointId",
+				"chargingPointStatus"
+			],
+			"additionalProperties": false
+		},
+		"ScheduledChargingProcess": {
+			"description": "This type represents a charging process in the future.",
+			"type": "object",
+			"properties": {
+				"presystemId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"chargingRequestId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"chargingProcessId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"vehicleId": {
+					"$ref": "#/definitions/VehicleIdentifier"
+				},
+				"startTime": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				},
+				"chargingPredictionData": {
+					"$ref": "#/definitions/ChargingPredictionData"
+				}
+			},
+			"required": [
+				"chargingRequestId",
+				"vehicleId",
+				"chargingPredictionData"
+			],
+			"additionalProperties": false
+		},
+		"DepotInfo": {
+			"description": "This type represents depot information sent by a load management system to a presystem.",
+			"type": "object",
+			"properties": {
+				"depotId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"name": {
+					"description": "This type represents name of the depot.",
+					"type": "string",
+					"additionalProperties": false
+				},
+				"chargingStationInfoList": {
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/ChargingStationInfo"
+					},
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"depotId",
+				"chargingStationInfoList"
+			],
+			"additionalProperties": false
+		},
+		"ChargingStationInfo": {
+			"type": "object",
+			"properties": {
+				"chargingStationId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"chargingStationStatus": {
+					"$ref": "#/definitions/ChargingStationStatus"
+				},
+				"chargingPointInfoList": {
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/ChargingPointInfo"
+					},
+					"additionalProperties": false
+				},
+				"chargingStationFaultInfo": {
+					"$ref": "#/definitions/ChargingStationFaultInfo"
+				},
+				"totalPower": {
+					"type": "number",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"chargingStationId",
+				"chargingStationStatus",
+				"chargingPointInfoList"
+			],
+			"additionalProperties": false
+		}
+	}
+}

--- a/v1.1/ProvideChargingInformationResponse.json
+++ b/v1.1/ProvideChargingInformationResponse.json
@@ -1,0 +1,9 @@
+{
+   "$schema": "http://json-schema.org/draft-04/schema#",
+   "$id": "urn:VDV463:1:0:0:ProvideChargingInformationResponse",
+   "comment": "VDV463 1.0.0 FINAL",
+   "title": "ProvideChargingInformationResponse",
+   "description": "This type represents the response data sent by the presystem to the load management system as a result associated with the charging information previously sent by the load management system.",
+   "additionalProperties": false,
+   "type": "object"
+}

--- a/v1.1/ProvideChargingRequestsRequest.json
+++ b/v1.1/ProvideChargingRequestsRequest.json
@@ -1,0 +1,186 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"$id": "urn:VDV463:1:0:0:ProvideChargingRequestsRequest",
+	"comment": "VDV463 1.0.0 FINAL",
+	"title": "ProvideChargingRequestsRequest",
+	"description": "This type represents the data associated with charging requests sent by a presystem to a load management system.",
+	"type": "object",
+	"properties": {
+		"chargingRequestList": {
+			"type": "array",
+			"minItems": 1,
+			"items": {
+				"$ref": "#/definitions/ChargingRequest"
+			},
+			"additionalProperties": false
+		}
+	},
+	"required": [
+		"chargingRequestList"
+	],
+	"additionalProperties": false,
+	"definitions": {
+		"VehicleIdentifier": {
+			"description": "This type represents an unique vehicle identifier associated with VDV261.",
+			"type": "string",
+			"additionalProperties": false
+		},
+		"UniqueIdentifier": {
+			"description": "This type represents an unique identifier according to RFC3986.",
+			"type": "string",
+			"format": "uri",
+			"additionalProperties": false
+		},
+		"ChargingInstruction": {
+			"type": "string",
+			"additionalProperties": false,
+			"enum": [
+				"Normal",
+				"Changed",
+				"Terminate"
+			]
+		},
+		"ChargingRequestData": {
+			"type": "object",
+			"properties": {
+				"expectedArrivalTimeAtChargingPoint": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				},
+				"expectedSocAtArrival": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"minTargetSoc": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"maxTargetSoc": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"requestedTimeForDeparture": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				},
+				"adHocCharging": {
+					"type": "boolean",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"minTargetSoc",
+				"maxTargetSoc"
+			],
+			"additionalProperties": false
+		},
+		"PreconditioningRequest": {
+			"type": "string",
+			"additionalProperties": false,
+			"enum": [
+				"WarmWaterAndVentilation",
+				"HotWaterAndHeating",
+				"NoWaterCoolingOrVentilation",
+				"NoClimaticPreconditioningOrSNA"
+			]
+		},
+		"AutomaticPreconditioning": {
+			"description": "This type imposes properties regarding automatic preconditioning.",
+			"type": "object",
+			"properties": {
+				"preconditioningRequest": {
+					"$ref": "#/definitions/PreconditioningRequest"
+				},
+				"ambientTemperature": {
+					"type": "number",
+					"additionalProperties": false
+				},
+				"requestedStartTime": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				},
+				"requestedFinishTime": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"preconditioningRequest"
+			],
+			"additionalProperties": false
+		},
+		"ManualPreconditioning": {
+			"description": "This type imposes properties regarding manual preconditioning.",
+			"type": "object",
+			"properties": {
+				"hvacPreconditioningStartTime": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				},
+				"hvacAuxiliaryConsumerPower": {
+					"type": "integer",
+					"additionalProperties": false
+				},
+				"systemPreconditioningStartTime": {
+					"type": "string",
+					"format": "date-time",
+					"additionalProperties": false
+				},
+				"systemAuxiliaryConsumerPower": {
+					"type": "integer",
+					"additionalProperties": false
+				}
+			},
+			"required": [
+				"hvacPreconditioningStartTime",
+				"systemPreconditioningStartTime"
+			],
+			"additionalProperties": false
+		},
+		"ChargingRequest": {
+			"description": "This type represents a charging request.",
+			"type": "object",
+			"properties": {
+				"chargingPointId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"vehicleId": {
+					"$ref": "#/definitions/VehicleIdentifier"
+				},
+				"chargingRequestId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"chargingProcessId": {
+					"$ref": "#/definitions/UniqueIdentifier"
+				},
+				"priority": {
+					"type": "integer",
+					"additionalProperties": false
+				},
+				"chargingInstruction": {
+					"$ref": "#/definitions/ChargingInstruction"
+				},
+				"chargingRequestData": {
+					"$ref": "#/definitions/ChargingRequestData"
+				},
+				"automaticPreconditioning": {
+					"$ref": "#/definitions/AutomaticPreconditioning"
+				},
+				"manualPreconditioning": {
+					"$ref": "#/definitions/ManualPreconditioning"
+				}
+			},
+			"required": [
+				"vehicleId",
+				"chargingRequestId",
+				"chargingRequestData"
+			],
+			"additionalProperties": false
+		}
+	}
+}

--- a/v1.1/ProvideChargingRequestsResponse.json
+++ b/v1.1/ProvideChargingRequestsResponse.json
@@ -1,0 +1,9 @@
+{
+   "$schema": "http://json-schema.org/draft-04/schema#",
+   "$id": "urn:VDV463:1:0:0:ProvideChargingRequestsResponse",
+   "comment": "VDV463 1.0.0 FINAL",
+   "title": "ProvideChargingRequestsResponse",
+   "description": "This type represents the response data sent by the load management system to the presystem as a result associated with the charging requests previously sent by the presystem.",
+   "additionalProperties": false,
+   "type": "object"
+}


### PR DESCRIPTION
Dieser Pull-Request ergänzt `requestedStartTime `als optionales Feld zu `AutomaticPreconditioning` für die Schemadatei `ProvideChargingRequestsRequest.json`.

Damit wird #5 gelöst. (Closes #5)



