### PR TITLE
Add Validations to JSON Schema Properties

### DIFF
--- a/v1.1/ProvideChargingInformationRequest.json
+++ b/v1.1/ProvideChargingInformationRequest.json
@@ -25,7 +25,7 @@
 			"additionalProperties": false
 		},
 		"EvccIdentifier": {
-			"description": "This type represents a mac adress of electric vehicle communication controller associated with ISO 15118.",
+			"description": "This type represents a mac address of electric vehicle communication controller associated with ISO 15118.",
 			"type": "string",
 			"additionalProperties": false
 		},
@@ -143,10 +143,14 @@
 			"properties": {
 				"stateOfHealth": {
 					"type": "number",
+					"minimum": 0,
+					"maximum": 100,
 					"additionalProperties": false
 				},
 				"stateOfCharge": {
 					"type": "number",
+					"minimum": 0,
+					"maximum": 100,
 					"additionalProperties": false
 				},
 				"temperature": {

--- a/v1.1/ProvideChargingRequestsRequest.json
+++ b/v1.1/ProvideChargingRequestsRequest.json
@@ -48,14 +48,20 @@
 				},
 				"expectedSocAtArrival": {
 					"type": "number",
+					"minimum": 0,
+					"maximum": 100,
 					"additionalProperties": false
 				},
 				"minTargetSoc": {
 					"type": "number",
+					"minimum": 0,
+					"maximum": 100,
 					"additionalProperties": false
 				},
 				"maxTargetSoc": {
 					"type": "number",
+					"minimum": 0,
+					"maximum": 100,
 					"additionalProperties": false
 				},
 				"requestedTimeForDeparture": {


### PR DESCRIPTION
The current JSON schemas lack validations for numerical properties. These validations ensure that the data conforms to expected value ranges. This aims to enhance the robustness and accuracy of the schema definitions.