### PR TITLE
Add missing additionalProperties for ChargingPredictionDataDepartureTime

### DIFF
--- a/schema/ProvideChargingInformationRequest.json
+++ b/schema/ProvideChargingInformationRequest.json
@@ -475,7 +475,8 @@
 			"required": [
 				"predictedDepartureTimeSoc",
 				"requestedTimeForDeparture"
-			]
+			],
+			"additionalProperties": false
 		},
 		"ChargingProgressPredictionList": {
 			"description": "This type represents a time series for predicting the charging process (internal extrapolation).",


### PR DESCRIPTION
Während der Bearbeitung des Issues https://github.com/VDVde/VDV463/issues/69 ist aufgefallen, dass der Typ ChargingPredictionDataDepartureTime im Schema noch nicht die übliche Bedingung `"additionalProperties": false` hat, wie es bei den anderen Typen der Fall ist.